### PR TITLE
Use auth settings with Sentinel

### DIFF
--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -13,10 +13,12 @@ from redis_sessions import settings
 if settings.SESSION_REDIS_SENTINEL_LIST is not None:
     from redis.sentinel import Sentinel
 
-    redis_server = Sentinel(settings.SESSION_REDIS_SENTINEL_LIST, socket_timeout=0.1) \
-                    .master_for(settings.SESSION_REDIS_SENTINEL_MASTER_ALIAS, 
-                                socket_timeout=0.1, 
-                                db=getattr(settings, 'SESSION_REDIS_DB', 0))
+    redis_server = Sentinel(
+        settings.SESSION_REDIS_SENTINEL_LIST,
+        socket_timeout=0.1,
+        db=getattr(settings, 'SESSION_REDIS_DB', 0),
+        password=getattr(settings, 'SESSION_REDIS_PASSWORD')
+    ).master_for(settings.SESSION_REDIS_SENTINEL_MASTER_ALIAS)
 
 elif settings.SESSION_REDIS_URL is not None:
 

--- a/redis_sessions/session.py
+++ b/redis_sessions/session.py
@@ -17,7 +17,7 @@ if settings.SESSION_REDIS_SENTINEL_LIST is not None:
         settings.SESSION_REDIS_SENTINEL_LIST,
         socket_timeout=0.1,
         db=getattr(settings, 'SESSION_REDIS_DB', 0),
-        password=getattr(settings, 'SESSION_REDIS_PASSWORD')
+        password=getattr(settings, 'SESSION_REDIS_PASSWORD', None)
     ).master_for(settings.SESSION_REDIS_SENTINEL_MASTER_ALIAS)
 
 elif settings.SESSION_REDIS_URL is not None:


### PR DESCRIPTION
At Fyndiq, we use redis auth with sentinel. We need django-redis-sessions to support it.